### PR TITLE
Don't rewrite urls that reference svg patterns

### DIFF
--- a/src/BundleTransformer.Core/PostProcessors/UrlRewritingCssPostProcessor.cs
+++ b/src/BundleTransformer.Core/PostProcessors/UrlRewritingCssPostProcessor.cs
@@ -269,7 +269,7 @@ namespace BundleTransformer.Core.PostProcessors
 		private string ProcessUrlRule(string parentAssetUrl, string assetUrl, string quote)
 		{
 			string processedAssetUrl = assetUrl;
-			if (!UrlHelpers.StartsWithProtocol(assetUrl) && !UrlHelpers.StartsWithDataUriScheme(assetUrl))
+			if (assetUrl[0] != '#' && !UrlHelpers.StartsWithProtocol(assetUrl) && !UrlHelpers.StartsWithDataUriScheme(assetUrl))
 			{
 				processedAssetUrl = _relativePathResolver.ResolveRelativePath(parentAssetUrl, assetUrl);
 			}


### PR DESCRIPTION
We can have url('#pattern') where #pattern is some svg pattern. This should not be rewritten.